### PR TITLE
[Feat] 이미지 업로드시 미리보기 및 firebase storage에 저장 #99

### DIFF
--- a/deco/src/@store/fileImageState.js
+++ b/deco/src/@store/fileImageState.js
@@ -1,0 +1,6 @@
+import { atom } from "recoil";
+
+export const fileImageState = atom({
+  key: "fileImageState",
+  default: "",
+});

--- a/deco/src/components/Common/FileUpload/FileUpload.jsx
+++ b/deco/src/components/Common/FileUpload/FileUpload.jsx
@@ -1,88 +1,65 @@
+import { forwardRef } from "react";
 import { ReactComponent as Upload } from "../../../assets/file_upload.svg";
 import styles from "./FileUpload.module.css";
-import { useState, useRef, useEffect } from "react";
+import { useRecoilState } from "recoil";
+import { fileImageState } from "@/@store/fileImageState";
 
-const FileUpload = ({ isSignUp }) => {
-  const [imgFile, setImgFile] = useState([]);
-  const imgRef = useRef([null, null]);
-  const [isVisible, setIsVisible] = useState([true, false]);
+const FileUpload = forwardRef(function FileUpload({ isSignUp, id }, ref) {
+  const [imgFile, setImgFile] = useRecoilState(fileImageState);
 
-  // 이미지 업로드 input의 onChange
-  const saveImgFile = (index) => {
-    const file = imgRef.current[index].files[0];
+  const onImageChange = (e) => {
+    const {
+      target: { files },
+    } = e;
+    const theFile = files[0];
     const reader = new FileReader();
-    reader.readAsDataURL(file);
-    reader.onloadend = () => {
-      const previewImgUrl = reader.result;
-      if (previewImgUrl) {
-        setImgFile([...imgFile, previewImgUrl]);
-      }
+    reader.onloadend = (finishedEvent) => {
+      const {
+        currentTarget: { result },
+      } = finishedEvent;
+      setImgFile(result);
     };
+    reader.readAsDataURL(theFile);
   };
-
-  useEffect(() => {
-    if (imgFile[0]) {
-      setIsVisible([true, true]);
-    }
-  }, [imgFile]);
 
   return (
     <div>
       {isSignUp ? (
         <div>
-          <label htmlFor="file" className={styles.profile_label_isSignUp}>
+          <label htmlFor={id} className={styles.profile_label_isSignUp}>
             <Upload className={styles.profile_image_isSignUp} /> 파일 업로드
           </label>
 
           <input
-            id="file"
+            id={id}
             type="file"
             accept="image/jpg, image/png, image/jpeg"
             name="profile"
             className={styles.profile_form_isSignUp}
+            ref={ref}
           />
         </div>
       ) : (
         <div className={styles.box}>
-          {isVisible.map((item, index) => {
-            {
-              index;
-            }
-            return item ? (
-              <div key={index} className={styles.imgBox}>
-                <label htmlFor="file" className={styles.profile_label}>
-                  <span className={styles.profile_image}>
-                    {!imgFile[index] && `파일 업로드`}
-                    {imgFile[index] && (
-                      <img
-                        src={
-                          imgFile[index]
-                            ? imgFile[index]
-                            : `/images/icon/user.png`
-                        }
-                        alt="프로필 이미지"
-                      />
-                    )}
-                  </span>
-                </label>
-                <input
-                  ref={(el) => {
-                    imgRef.current[index] = el;
-                  }}
-                  id="file"
-                  type="file"
-                  accept="image/jpg, image/png, image/jpeg"
-                  name="profile"
-                  className={styles.profile_form}
-                  onChange={() => saveImgFile(index)}
-                />
-              </div>
-            ) : null;
-          })}
+          <div className={styles.imgBox}>
+            <label htmlFor={id} className={styles.profile_label}>
+              <span className={styles.profile_image}>파일업로드</span>
+              {imgFile && <img src={imgFile} alt="프로필 이미지" />}
+            </label>
+            <input
+              id={id}
+              type="file"
+              accept="image/jpg, image/png, image/jpeg"
+              name="profile"
+              className={styles.profile_form}
+              ref={ref}
+              onChange={onImageChange}
+            />
+          </div>
         </div>
       )}
     </div>
   );
-};
+});
 
 export default FileUpload;

--- a/deco/src/components/Common/FileUpload/FileUpload.jsx
+++ b/deco/src/components/Common/FileUpload/FileUpload.jsx
@@ -49,7 +49,7 @@ const FileUpload = ({ isSignUp }) => {
               index;
             }
             return item ? (
-              <div key={index}>
+              <div key={index} className={styles.imgBox}>
                 <label htmlFor="file" className={styles.profile_label}>
                   <span className={styles.profile_image}>
                     {!imgFile[index] && `파일 업로드`}

--- a/deco/src/components/Common/FileUpload/FileUpload.jsx
+++ b/deco/src/components/Common/FileUpload/FileUpload.jsx
@@ -1,7 +1,31 @@
 import { ReactComponent as Upload } from "../../../assets/file_upload.svg";
 import styles from "./FileUpload.module.css";
+import { useState, useRef, useEffect } from "react";
 
 const FileUpload = ({ isSignUp }) => {
+  const [imgFile, setImgFile] = useState([]);
+  const imgRef = useRef([null, null]);
+  const [isVisible, setIsVisible] = useState([true, false]);
+
+  // 이미지 업로드 input의 onChange
+  const saveImgFile = (index) => {
+    const file = imgRef.current[index].files[0];
+    const reader = new FileReader();
+    reader.readAsDataURL(file);
+    reader.onloadend = () => {
+      const previewImgUrl = reader.result;
+      if (previewImgUrl) {
+        setImgFile([...imgFile, previewImgUrl]);
+      }
+    };
+  };
+
+  useEffect(() => {
+    if (imgFile[0]) {
+      setIsVisible([true, true]);
+    }
+  }, [imgFile]);
+
   return (
     <div>
       {isSignUp ? (
@@ -19,18 +43,42 @@ const FileUpload = ({ isSignUp }) => {
           />
         </div>
       ) : (
-        <div>
-          <label htmlFor="file" className={styles.profile_label}>
-            <Upload className={styles.profile_image} /> 파일 업로드
-          </label>
-
-          <input
-            id="file"
-            type="file"
-            accept="image/jpg, image/png, image/jpeg"
-            name="profile"
-            className={styles.profile_form}
-          />
+        <div className={styles.box}>
+          {isVisible.map((item, index) => {
+            {
+              index;
+            }
+            return item ? (
+              <div key={index}>
+                <label htmlFor="file" className={styles.profile_label}>
+                  <span className={styles.profile_image}>
+                    {!imgFile[index] && `파일 업로드`}
+                    {imgFile[index] && (
+                      <img
+                        src={
+                          imgFile[index]
+                            ? imgFile[index]
+                            : `/images/icon/user.png`
+                        }
+                        alt="프로필 이미지"
+                      />
+                    )}
+                  </span>
+                </label>
+                <input
+                  ref={(el) => {
+                    imgRef.current[index] = el;
+                  }}
+                  id="file"
+                  type="file"
+                  accept="image/jpg, image/png, image/jpeg"
+                  name="profile"
+                  className={styles.profile_form}
+                  onChange={() => saveImgFile(index)}
+                />
+              </div>
+            ) : null;
+          })}
         </div>
       )}
     </div>

--- a/deco/src/components/Common/FileUpload/FileUpload.module.css
+++ b/deco/src/components/Common/FileUpload/FileUpload.module.css
@@ -1,18 +1,36 @@
+.box {
+  display: flex;
+  flex-direction: row;
+}
+
+.imgBox {
+  margin-right: 10px;
+}
+
+img {
+  width: 100px;
+  height: 100px;
+  position: absolute;
+  top: 0;
+  left: 0;
+  object-fit: cover;
+}
 /* isSignUp = false */
 .profile_label {
-  background-color: var(--secondary);
-  color: white;
-  border: none;
-  width: 185px;
-  height: 44px;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  cursor: pointer;
+  display: block;
+  width: 100px;
+  height: 100px;
+  border-radius: 5px;
+  border: 1px dashed var(--gray-400);
+  position: relative;
 }
 
 .profile_image {
-  padding-right: 10px;
+  display: block;
+  line-height: 100px;
+  text-align: center;
+  color: var(--gray-400);
+  font-size: 14px;
 }
 
 .profile_form {
@@ -47,5 +65,9 @@
   border: 0;
   color: white;
   cursor: pointer;
+  display: none;
+}
+
+input[type="file"] {
   display: none;
 }

--- a/deco/src/components/Common/QuestionAnswer/QuestionAnswer.jsx
+++ b/deco/src/components/Common/QuestionAnswer/QuestionAnswer.jsx
@@ -4,15 +4,18 @@ import Styles from "@/components/Common/QuestionAnswer/QuestionAnswer.module.css
 import SubmitButton from "@/components/Common/SubmitButton/SubmitButton";
 import { commentState } from "@/@store/commentState";
 import { useCreateData } from "@/firebase/firestore";
+import { useState } from "react";
+import { useParams } from "react-router-dom";
 
 /* 텍스트 지우는 함수 */
 function clearText(target) {
   target.value = "";
 }
 
-const QuestionAnswer = () => {
+const QuestionAnswer = ({ title, ...restProps }) => {
   const [comment, setComment] = useRecoilState(commentState);
   const { createData } = useCreateData("comments");
+  const commentsId = useParams();
 
   function onChange(e) {
     setComment(e.target.value);
@@ -26,12 +29,15 @@ const QuestionAnswer = () => {
     // firebase 이용하는 방법
     await createData({
       user: {
-        userid: "임시 아이디",
+        userId: "임시 아이디",
+        profile: null,
         nickname: "임시 닉네임",
       },
+      date: new Date().getTime(),
       comment: commentWriteField.value,
+      commentId: +commentsId.id,
     });
-
+    // indexData.current += 1;
     clearText(commentWriteField);
 
     console.log("comments 콜렉션에 comments 데이터 생성");
@@ -56,7 +62,7 @@ const QuestionAnswer = () => {
 
   return (
     <div className={Styles.answerWrite}>
-      <h2>답변하기</h2>
+      <h2>{title}</h2>
 
       <form onSubmit={submitData}>
         <textarea
@@ -64,6 +70,7 @@ const QuestionAnswer = () => {
           name="comment"
           placeholder="질문에 대한 답변을 하려면 로그인을 해주세요"
           onChange={onChange}
+          {...restProps}
         ></textarea>
 
         <div className={Styles.submitButton}>
@@ -75,3 +82,9 @@ const QuestionAnswer = () => {
 };
 
 export default QuestionAnswer;
+
+/* Props -------------------------------------------------------------------- */
+
+QuestionAnswer.defaultProps = {
+  title: "답변하기",
+};

--- a/deco/src/components/Common/SubmitButton/SubmitButton.jsx
+++ b/deco/src/components/Common/SubmitButton/SubmitButton.jsx
@@ -1,20 +1,17 @@
-import { useId } from "react";
 import styles from "./SubmitButton.module.css";
 
 const SubmitButton = ({ writeButton, title, ...restProps }) => {
-  const id = useId();
-
   return (
     <>
       {writeButton ? (
         <div className={styles.container_writeButton}>
-          <button id={id} className={styles.button_writeButton} {...restProps}>
+          <button className={styles.button_writeButton} {...restProps}>
             {title}
           </button>
         </div>
       ) : (
         <div className={styles.container}>
-          <button id={id} className={styles.button} {...restProps}>
+          <button className={styles.button} {...restProps}>
             {title}
           </button>
         </div>

--- a/deco/src/components/QuestionPage/QuestionWrite/QuestionWrite.jsx
+++ b/deco/src/components/QuestionPage/QuestionWrite/QuestionWrite.jsx
@@ -9,22 +9,34 @@ import { collection, addDoc } from "firebase/firestore";
 import { dbService } from "@/firebase/app";
 import { contentState } from "@/@store/contentState";
 import { hashTagListState } from "@/@store/hashTagListState";
+import { useId } from "react";
+import { useUploadFiles } from "@/firebase/storage";
+import { fileImageState } from "@/@store/fileImageState";
 
 const QuestionWrite = () => {
   const inputTitle = useRecoilValue(titleState);
   const inputContent = useRecoilValue(contentState);
   const inputHashTagList = useRecoilValue(hashTagListState);
+  const inputFileImage = useRecoilValue(fileImageState);
 
-  const submitTitle = async (e) => {
+  //파일 업로드
+  const id = useId();
+  const { fileInputRef, uploadFiles } = useUploadFiles();
+
+  const onSubmit = async (e) => {
     e.preventDefault();
     console.log("해시태그", inputHashTagList);
     console.log("1" + inputContent);
+
+    uploadFiles();
+    console.log("파일 업로드 요청");
 
     try {
       const docRef = await addDoc(collection(dbService, "question"), {
         title: inputTitle,
         content: inputContent,
         hashtag: inputHashTagList,
+        file: inputFileImage,
       });
       console.log("성공?", docRef.id);
     } catch (e) {
@@ -65,10 +77,10 @@ const QuestionWrite = () => {
 
         <WriteInput isQuestion={true} />
         <TagInput isQuestion={true} />
-        <div className={styles.rowButton}>
-          <FileUpload isSignUp={false} />
-          <SubmitButton onClick={submitTitle} title="등록" writeButton={true} />
-        </div>
+        <form className={styles.rowButton}>
+          <FileUpload isSignUp={false} id={id} ref={fileInputRef} />
+          <SubmitButton onClick={onSubmit} title="등록" writeButton={true} />
+        </form>
       </div>
     </div>
   );

--- a/deco/src/firebase/storage/index.js
+++ b/deco/src/firebase/storage/index.js
@@ -1,0 +1,6 @@
+import { app } from "../app";
+import { getStorage } from "firebase/storage";
+
+export const storage = getStorage(app);
+
+export * from "./useUploadFile";

--- a/deco/src/firebase/storage/useUploadFile.js
+++ b/deco/src/firebase/storage/useUploadFile.js
@@ -1,0 +1,81 @@
+import { useCallback, useMemo, useRef, useState } from "react";
+import { getDownloadURL, ref, uploadBytes } from "firebase/storage";
+import { storage } from "./index";
+
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Firebase 스토리지 파일 업로드 훅
+ * @param {{ dirName?: string; usingId?: boolean; }}
+ * @returns {{ fileInputRef, uploadFiles, isLoading, error, urlList }}
+ */
+export function useUploadFiles({ dirName = "assets", usingId = true } = {}) {
+  const fileInputRef = useRef(null);
+
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const [urlList, setUrlList] = useState(null);
+
+  const uploadFiles = useCallback(async () => {
+    const { current: fileInput } = fileInputRef;
+
+    if (fileInput) {
+      const files = fileInput.files;
+
+      const filesRef = Array.from(files).map((file) => {
+        if (!file.name.includes(".")) {
+          throw new TypeError(
+            "업로드 할 파일에 확장자가 포함되어 있지 않습니다.",
+          );
+        }
+        const [fileName = "", fileExt = ""] = file.name.split(".");
+        const fileId = usingId ? `${generateId()}.` : "";
+        return ref(storage, `${dirName}/${fileName}.${fileId}${fileExt}`);
+      });
+
+      setIsLoading(true);
+
+      try {
+        const uploadPromises = filesRef.map((fileRef, index) =>
+          uploadBytes(fileRef, files[index]),
+        );
+
+        const uploadSanpshots = await Promise.all(uploadPromises);
+
+        const downloadURLs = uploadSanpshots.map((snapshot) =>
+          getDownloadURL(snapshot.ref),
+        );
+
+        const downloadURLList = await Promise.all(downloadURLs);
+
+        setUrlList(downloadURLList);
+
+        fileInput.value = "";
+      } catch (error) {
+        setError(error);
+      } finally {
+        setIsLoading(false);
+      }
+    }
+  }, [dirName, usingId]);
+
+  return useMemo(
+    () => ({ fileInputRef, uploadFiles, isLoading, error, urlList }),
+    [error, isLoading, uploadFiles, urlList],
+  );
+}
+
+function generateId({ prefix = "euid", digit = 9 } = {}) {
+  const suffix = "abcdefghijklmnopqrstuvwxyz-_+=";
+  return `${prefix}-${getRandomNumber(getDigitNumber(digit))}${suffix[
+    getRandomNumber(suffix.length - 1)
+  ][getRandomNumber(2) > 0 ? "toUpperCase" : "toLowerCase"]()}`;
+}
+
+function getRandomNumber(n = 10) {
+  return Math.floor(Math.random() * n);
+}
+
+function getDigitNumber(digit = 1) {
+  return new Number(`1e${digit}`).valueOf();
+}


### PR DESCRIPTION
## ✨ 구현 기능 명세
![이미지미리보기](https://user-images.githubusercontent.com/111109573/227610003-4c3b813a-c250-4ae3-9874-10488fd92b62.gif)
![스토리지](https://user-images.githubusercontent.com/111109573/227610022-bf3a51c2-0e88-4ff2-b2c6-c06a27d01855.gif)

- 이미지 미리보기 기능 구현
- 이미지 업로드할 때 firebase storage에 이미지 저장
- 이미지 업로드할 때 firestore에 이미지 주소 데이터 저장

## 🕰 소요시간
- 하루 넘게 걸렸습니다. (이틀?)

## 😭 어려웠던 점
- firebase storage에 업로드하는데 시간이 걸렸습니다.
- 이미지 주소 데이터는 데이터베이스에 잘 들어오는데 업로드가 되지 않아서.. 코드를 계속 수정했습니다.
- 처음엔 이미지를 2개 업로드하기위해 컴포넌트 스타일을 변경했고, 이미지를 한개 올린 후 바로 다음에 추가하는 창을 한개 더 나오게 구현을 했습니다. 근데 스토리지에 업로드 하는 것이 우선이라 생각해서 일단 1개만 되도록 코드를 수정했습니다. (추후에 다시 map을 돌려서 2개가 나오도록 하고 스토리지에 업로드 하는 방법으로 리팩토링 해야할 것 같습니다.)
