### PR TITLE
[Feat] 묻고 답하기 카테고리별 정렬 및 추천순 조회순 정렬 완료 #12

### DIFF
--- a/deco/src/components/Common/Article/Article.jsx
+++ b/deco/src/components/Common/Article/Article.jsx
@@ -31,7 +31,7 @@ const Article = ({ item }) => {
       <div className={styles.hashAndAdditionalInfo}>
         <div className={styles.hash}>
           {category ? <QuestionCategory categoryName={category} /> : null}
-          {hashTag.map((item, index) => (
+          {hashTag?.map((item, index) => (
             <Hashtag key={index} content={item} />
           ))}
         </div>

--- a/deco/src/components/Common/Category/Category.jsx
+++ b/deco/src/components/Common/Category/Category.jsx
@@ -1,19 +1,18 @@
 import React from "react";
-import { Link } from "react-router-dom";
 import styles from "./Category.module.css";
 
-const Category = ({ category1 = "", category2 = "", path = "",...restprps }) => {
+const Category = ({ category1 = "", category2 = "", path = "",...restprops }) => {
 
   return (
     <div className={styles.container}>
       <div className={styles.inner}>
-        <button to={path} href={path} name="all" {...restprps} >
+        <button to={path} href={path} name="all" {...restprops} >
           전체
         </button>
-        <button to="/" href="/" name={category1} {...restprps} >
+        <button to="/" href="/" name={category1} {...restprops} >
           {category1}
         </button>
-        <button to="/" href="/" name={category2} {...restprps} >
+        <button to="/" href="/" name={category2} {...restprops} >
           {category2}
         </button>
       </div>

--- a/deco/src/components/Common/Category/Category.jsx
+++ b/deco/src/components/Common/Category/Category.jsx
@@ -2,19 +2,20 @@ import React from "react";
 import { Link } from "react-router-dom";
 import styles from "./Category.module.css";
 
-const Category = ({ category1 = "", category2 = "", path = "" }) => {
+const Category = ({ category1 = "", category2 = "", path = "",...restprps }) => {
+
   return (
     <div className={styles.container}>
       <div className={styles.inner}>
-        <Link to={path} href={path}>
+        <button to={path} href={path} name="all" {...restprps} >
           전체
-        </Link>
-        <Link to="/" href="/">
+        </button>
+        <button to="/" href="/" name={category1} {...restprps} >
           {category1}
-        </Link>
-        <Link to="/" href="/">
+        </button>
+        <button to="/" href="/" name={category2} {...restprps} >
           {category2}
-        </Link>
+        </button>
       </div>
     </div>
   );

--- a/deco/src/components/Common/Category/Category.module.css
+++ b/deco/src/components/Common/Category/Category.module.css
@@ -14,3 +14,7 @@
   font-size: var(--text-md);
   font-weight: 600;
 }
+.inner button {
+  border: none;
+  background-color: white;
+}

--- a/deco/src/components/Common/Sort/Sort.jsx
+++ b/deco/src/components/Common/Sort/Sort.jsx
@@ -1,13 +1,13 @@
 import React from "react";
 import styles from "./Sort.module.css";
 
-const Sort = () => {
+const Sort = ({...restprops}) => {
   return (
     <div className={styles.container}>
-      <button className={styles.sortNew} type="button">
+      <button className={styles.sortNew} type="button" name="new" {...restprops}>
         최신순
       </button>
-      <button className={styles.sortRecommendation} type="button">
+      <button className={styles.sortRecommendation} type="button" name="like" {...restprops}>
         추천순
       </button>
     </div>

--- a/deco/src/components/QuestionPage/QuestionList.jsx
+++ b/deco/src/components/QuestionPage/QuestionList.jsx
@@ -12,8 +12,8 @@ import styles from "./QuestionList.module.css";
 
 const QuestionList = () => {
   let questionData = useRecoilState(getQuestion);
-  let newData = questionData[0].filter((item) => item.id !== undefined)
-  let [filteredData, setFilterdData] = useState([...newData]
+  let originalData = questionData[0].filter((item) => item.id !== undefined)
+  let [filteredData, setFilterdData] = useState([...originalData]
   );
   let [category, setCategory] = useState("전체");
 
@@ -35,14 +35,14 @@ const QuestionList = () => {
   const onClickSort = async (e) => {
     e.preventDefault();
     if (e.target.name == "like") {
-      let arr = [...newData];
+      let arr = [...originalData];
       let newArr = arr.sort(function (a, b) {
         return b.hits - a.hits;
       });
       setFilterdData(newArr);
     }
     if (e.target.name == "new") {
-      let arr = [...newData];
+      let arr = [...originalData];
       let newArr = arr
         .sort(function (a, b) {
           return new Date(b.date).getTime() - new Date(a.date).getTime();

--- a/deco/src/components/QuestionPage/QuestionList.jsx
+++ b/deco/src/components/QuestionPage/QuestionList.jsx
@@ -13,8 +13,8 @@ import styles from "./QuestionList.module.css";
 const QuestionList = () => {
   let questionData = useRecoilState(getQuestion);
   let originalData = questionData[0].filter((item) => item.id !== undefined)
-  let [filteredData, setFilterdData] = useState([...originalData]
-  );
+console.log(originalData)
+  let [filteredData, setFilterdData] = useState([...originalData]);
   let [category, setCategory] = useState("전체");
 
 
@@ -35,13 +35,16 @@ const QuestionList = () => {
   const onClickSort = async (e) => {
     e.preventDefault();
     if (e.target.name == "like") {
+      console.log("추천순")
       let arr = [...originalData];
       let newArr = arr.sort(function (a, b) {
-        return b.hits - a.hits;
+        return b.like - a.like;
       });
+      console.log(newArr)
       setFilterdData(newArr);
     }
     if (e.target.name == "new") {
+      console.log("최신순")
       let arr = [...originalData];
       let newArr = arr
         .sort(function (a, b) {

--- a/deco/src/components/QuestionPage/QuestionList.jsx
+++ b/deco/src/components/QuestionPage/QuestionList.jsx
@@ -12,7 +12,7 @@ import styles from "./QuestionList.module.css";
 
 const QuestionList = () => {
   let questionData = useRecoilState(getQuestion);
-  let filteredData= questionData[0].filter((item) => item.id !== undefined);
+  let [filteredData,setFilteredData]= useState(questionData[0].filter((item) => item.id !== undefined));
   let [category, setCategory] = useState("전체");
 
 
@@ -30,6 +30,26 @@ const QuestionList = () => {
     }
   };
 
+  const onClickSort = async (e) => {
+    e.preventDefault();
+    if (e.target.name == "like") {
+      let arr = [...filteredData];
+      let newArr = arr.sort(function (a, b) {
+        return b.hits - a.hits;
+      });
+      setFilteredData(newArr);
+    }
+    if (e.target.name == "new") {
+      let arr = [...filteredData];
+      let newArr = arr
+        .sort(function (a, b) {
+          return new Date(b.date).getTime() - new Date(a.date).getTime();
+        })
+        setFilteredData(newArr);
+    }
+  };
+
+
   return (
     <>
       <BoardBanner
@@ -45,7 +65,7 @@ const QuestionList = () => {
         <Hashtag content="JavaScript" />
         <Hashtag content="HTML " />
       </div>
-      <Sort/>
+      <Sort onClick={onClickSort}/>
 
       {category == "전체"
         ? filteredData.map((item) => {

--- a/deco/src/components/QuestionPage/QuestionList.jsx
+++ b/deco/src/components/QuestionPage/QuestionList.jsx
@@ -13,8 +13,7 @@ import styles from "./QuestionList.module.css";
 const QuestionList = () => {
   let questionData = useRecoilState(getQuestion);
   let originalData = questionData[0].filter((item) => item.id !== undefined)
-console.log(originalData)
-  let [filteredData, setFilterdData] = useState([...originalData]);
+  let [filteredData, setFilteredData] = useState([...originalData]);
   let [category, setCategory] = useState("전체");
 
 
@@ -41,7 +40,7 @@ console.log(originalData)
         return b.like - a.like;
       });
       console.log(newArr)
-      setFilterdData(newArr);
+      setFilteredData(newArr);
     }
     if (e.target.name == "new") {
       console.log("최신순")
@@ -50,7 +49,7 @@ console.log(originalData)
         .sort(function (a, b) {
           return new Date(b.date).getTime() - new Date(a.date).getTime();
         })
-      setFilterdData(newArr);
+        setFilteredData(newArr);
     }
   };
   return (

--- a/deco/src/components/QuestionPage/QuestionList.jsx
+++ b/deco/src/components/QuestionPage/QuestionList.jsx
@@ -1,5 +1,5 @@
-import { getQuestion } from "@/@store/getQuestionData";
-import React from "react";
+import { getQuestion} from "@/@store/getQuestionData";
+import React, { useState } from "react";
 import { useRecoilState } from "recoil";
 import Article from "../Common/Article/Article";
 import BoardBanner from "../Common/BoardBanner/BoardBanner";
@@ -12,7 +12,23 @@ import styles from "./QuestionList.module.css";
 
 const QuestionList = () => {
   let questionData = useRecoilState(getQuestion);
-  let filteredData = questionData[0].filter((item) => item.id !== undefined);
+  let filteredData= questionData[0].filter((item) => item.id !== undefined);
+  let [category, setCategory] = useState("전체");
+
+
+  const onClickCategory = async (e) => {
+    e.preventDefault();
+    if (e.target.name == "all") {
+      setCategory("전체");
+    }
+    if (e.target.name == "기술") {
+      setCategory("기술");
+    }
+
+    if (e.target.name == "커리어") {
+      setCategory("커리어");
+    }
+  };
 
   return (
     <>
@@ -22,17 +38,24 @@ const QuestionList = () => {
         write="질문하기"
         path="/question/write"
       />
-      <Category category1="기술" category2="커리어" />
+      <Category category1="기술" category2="커리어" onClick={onClickCategory} />
       <SearchForm />
       <div className={styles.hashtagContainer}>
         <Hashtag content="React" />
         <Hashtag content="JavaScript" />
         <Hashtag content="HTML " />
       </div>
-      <Sort />
-      {filteredData.map((item) => {
-        return <Article key={item.id} item={item} />;
-      })}
+      <Sort/>
+
+      {category == "전체"
+        ? filteredData.map((item) => {
+            return <Article key={item?.id} item={item} />;
+          })
+        : filteredData
+            .filter((item) => item.category === category)
+            .map((item) => {
+              return <Article key={item?.id} item={item} />;
+            })}
       <Pagination />
     </>
   );

--- a/deco/src/components/QuestionPage/QuestionList.jsx
+++ b/deco/src/components/QuestionPage/QuestionList.jsx
@@ -12,7 +12,9 @@ import styles from "./QuestionList.module.css";
 
 const QuestionList = () => {
   let questionData = useRecoilState(getQuestion);
-  let [filteredData,setFilteredData]= useState(questionData[0].filter((item) => item.id !== undefined));
+  let newData = questionData[0].filter((item) => item.id !== undefined)
+  let [filteredData, setFilterdData] = useState([...newData]
+  );
   let [category, setCategory] = useState("전체");
 
 
@@ -33,23 +35,21 @@ const QuestionList = () => {
   const onClickSort = async (e) => {
     e.preventDefault();
     if (e.target.name == "like") {
-      let arr = [...filteredData];
+      let arr = [...newData];
       let newArr = arr.sort(function (a, b) {
         return b.hits - a.hits;
       });
-      setFilteredData(newArr);
+      setFilterdData(newArr);
     }
     if (e.target.name == "new") {
-      let arr = [...filteredData];
+      let arr = [...newData];
       let newArr = arr
         .sort(function (a, b) {
           return new Date(b.date).getTime() - new Date(a.date).getTime();
         })
-        setFilteredData(newArr);
+      setFilterdData(newArr);
     }
   };
-
-
   return (
     <>
       <BoardBanner
@@ -65,7 +65,7 @@ const QuestionList = () => {
         <Hashtag content="JavaScript" />
         <Hashtag content="HTML " />
       </div>
-      <Sort onClick={onClickSort}/>
+      <Sort onClick={onClickSort} />
 
       {category == "전체"
         ? filteredData.map((item) => {


### PR DESCRIPTION
## ✨ 구현 기능 명세
- 카테고리별 정렬 및 추천순 조회순 정렬 완료

## 🕰 소요시간
- 5시간

## 😭 어려웠던 점
- 리코일로 전역state를 변경하기 위해서 selector의 set을 사용했었습니다. 하지만 그로인해 새로고침이 발생하게 되었고 이후에 useState를 사용하여 조건부 렌더링을 진행하니 새로고침없이 렌더링되는것을 확인했습니다. 리코일에 과하게 집착해서 시간이 더 늦어진것같습니다...
- 또한 추천순 및 최신순 정렬시 깊은복사를 하지않고 전역state를 그대로 처리하니 수정된 데이터내에서만 정렬이 진행되어 기능이 정상적으로 작동하지 않았습니다. 이를 해결하기 위해 spered operator를 사용하여 깊은 복사를 진행한뒤 원본데이터를 참조하여 추천순 및 최신순으로 렌더링 되도록 작업했습니다.