### PR TITLE
[Add] 모든 카테고리에서 댓글 조회 가능 #133

### DIFF
--- a/deco/src/components/Common/Comment/Comment.jsx
+++ b/deco/src/components/Common/Comment/Comment.jsx
@@ -4,12 +4,14 @@ import React, { useEffect, useState } from "react";
 import styles from "@/components/Common/Comment/Comment.module.css";
 import { db } from "@/firebase/firestore";
 import { collection, onSnapshot, query, getDocs } from "firebase/firestore";
-import { useParams } from "react-router-dom";
+import { useLocation, useParams } from "react-router-dom";
 import { useAuthState } from "@/firebase/auth";
 
 const Comment = ({ id }) => {
   let [timeData, setTimeData] = useState([]);
   const questionId = useParams();
+  const {pathname} = useLocation();
+  const category = pathname.split("/")[1]
 
   useEffect(() => {
     const getData = async () => {
@@ -19,7 +21,7 @@ const Comment = ({ id }) => {
         const data = querySnapShot.docs.map((doc) => ({
           id: doc.id,
           ...doc.data(),
-        }));
+        })).filter((item)=>item.category == category);
         setTimeData(data);
       });
     };


### PR DESCRIPTION
- 필터링을 통해 모든 카테고리에서댓글 조회 가능

## ✨ 구현 기능 명세
-커뮤니티 페이지 댓글 조회 구현

## 🕰 소요시간
- 3시간

## 😭 어려웠던 점
- 댓글을 조회하는 컴포넌트에서는 묻고답하기의 댓글만 고정적으로 불러오도록 되어있어서 어떻게 하면 모든 게시판의 댓글들을 가져올 수 있도록 할 수 있을지 고민했습니다. useLocation을 사용해 주소창 파라미터를 가져왔고 거기서 원하는 게시판의 값을 split을 사용하여 가져오는 방법으로 해결했습니다.
- 이 방법을 사용하기 위해서는 댓글작성시 해당 게시판의 이름을 파이어베이스에 저장하도록 추가적인 기능 구현이 필요할것으로 보입니다. 
