### PR TITLE
[Refactor] 메인페이지 접근성고려 리팩토링

### DIFF
--- a/deco/src/components/MainPage/ShortcutButton/ShortcutButton.module.css
+++ b/deco/src/components/MainPage/ShortcutButton/ShortcutButton.module.css
@@ -5,3 +5,7 @@
   color: var(--white);
   padding: 0.625rem 1.125rem;
 }
+
+.button:focus {
+  outline: 2px solid #1c315e;
+}

--- a/deco/src/components/MainPage/ShortcutList/ShortcutList.jsx
+++ b/deco/src/components/MainPage/ShortcutList/ShortcutList.jsx
@@ -21,7 +21,7 @@ const MainPage = ({ list, ...restProps }) => {
         {list.map((item) => (
           <li key={item.id} className={styles.listWrap}>
             {renderIcon(item)}
-            <h3 className={styles.title}>{item.title}</h3>
+            <p className={styles.title}>{item.title}</p>
             <p className={styles.description}>{item.description}</p>
             <ShortcutButton to={item.to} />
           </li>

--- a/deco/src/pages/MainPage.jsx
+++ b/deco/src/pages/MainPage.jsx
@@ -1,14 +1,6 @@
-import React from "react";
 import Main from "@/components/MainPage/MainPage";
-import { useRecoilState } from "recoil";
-// import { authUserState } from "@/@store/authUserState";
 
 const MainPage = () => {
-  // const [authUser, setAuthUser] = useRecoilState(authUserState);
-  // console.log(authUser);
-  // React.useEffect(() => {
-  //   setTimeout(() => setAuthUser({ name: "동경" }), 2000);
-  // }, [setAuthUser]);
   return (
     <div>
       <Main />

--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "DECO",
-  "lockfileVersion": 2,
+  "lockfileVersion": 3,
   "requires": true,
   "packages": {}
 }


### PR DESCRIPTION
## ✨ 구현 기능 명세
- 라이트하우스로 체크했을 때 접근성에 맞게 태그를 변경함
- 메인페이지 바로가기 버튼에 탭키로 접근했을 때 명확히 보이도록 outline 색상 수정
- 불필요한 코드 및 주석 제거

## 🕰 소요시간
- 하루

## 😭 어려웠던 점
- 딱히 어려웠던 점은 없었습니다.
